### PR TITLE
Changes raw array pointers to a Span/Multispan

### DIFF
--- a/klib/graphics/string.hpp
+++ b/klib/graphics/string.hpp
@@ -61,7 +61,7 @@ namespace klib::graphics {
          * @param background 
          */
         template <typename Fb>
-        void draw(Fb& framebuffer, const char* str = nullptr, 
+        void draw(Fb& framebuffer, const char* str, 
             const klib::vector2i& position = {}, 
             const color foreground = klib::graphics::black, 
             const color background = klib::graphics::transparent) const 

--- a/klib/hardware/display/st7789.hpp
+++ b/klib/hardware/display/st7789.hpp
@@ -138,7 +138,7 @@ namespace klib::hardware::display {
                 PinDC::template set<false>();
 
                 // write the command
-                Bus::write(reinterpret_cast<const uint8_t *>(&command), sizeof(cmd));
+                Bus::write({reinterpret_cast<const uint8_t *>(&command), sizeof(cmd)});
 
                 // only write the data if we have arguments
                 if (size) {
@@ -146,7 +146,7 @@ namespace klib::hardware::display {
                     PinDC::template set<true>();
 
                     // write the data of the command
-                    Bus::write(arguments, size);
+                    Bus::write({arguments, size});
                 }
             }
 
@@ -374,11 +374,13 @@ namespace klib::hardware::display {
             if constexpr (!std::is_same_v<DmaRx, klib::io::dma::none>) {
                 // read memory into the rx buffer. Do not increment as we 
                 // do not care about the result of what we are reading
-                DmaRx::template read<false>(&rx, size);
+                DmaRx::template read<false>(std::span<uint8_t>{
+                    reinterpret_cast<uint8_t*>(&rx), size
+                });
             }
 
             // write to the dma channel
-            DmaTx::template write<true>(data, size);
+            DmaTx::template write<true>(std::span<const uint8_t>{data, size});
         }
     };
 }

--- a/klib/multispan.hpp
+++ b/klib/multispan.hpp
@@ -79,7 +79,7 @@ namespace klib {
          * @param first 
          * @param second 
          */
-        multispan(const G& first, const H& second):
+        constexpr multispan(const G& first, const H& second):
             first(first), second(second)
         {}
 
@@ -104,7 +104,7 @@ namespace klib {
          * 
          * @return uint32_t 
          */
-        uint32_t size() const {
+        constexpr uint32_t size() const {
             return first.size() + second.size();
         }
 
@@ -113,7 +113,7 @@ namespace klib {
          * 
          * @return uint32_t 
          */
-        uint32_t empty() const {
+        constexpr uint32_t empty() const {
             return size() == 0;
         }
     };

--- a/klib/multispan.hpp
+++ b/klib/multispan.hpp
@@ -72,7 +72,7 @@ namespace klib {
         using const_reference     = const element_type&;
 
         /**
-         * @brief Construct a new multiptr object using a initializer list, raw 
+         * @brief Construct a new multispan object using a initializer list, raw 
          * array(not a pointer) or std::array
          * 
          * for raw pointers {ptr, size} should be used as a parameter
@@ -116,6 +116,15 @@ namespace klib {
          */
         constexpr uint32_t empty() const {
             return size() == 0;
+        }
+
+        /**
+         * @brief Returns the amount of bytes the combined spans use
+         * 
+         * @return constexpr uint32_t 
+         */
+        constexpr uint32_t size_bytes() const {
+            return first.size_bytes() + second.size_bytes();
         }
     };
 }

--- a/klib/multispan.hpp
+++ b/klib/multispan.hpp
@@ -1,0 +1,117 @@
+#ifndef KLIB_MULTISPAN_HPP
+#define KLIB_MULTISPAN_HPP
+
+#include <cstdint>
+#include <span>
+
+namespace klib::detail {
+    /**
+     * @brief Multispan base for checking if we have a multispan 
+     * with type checking
+     * 
+     * @tparam T 
+     */
+    template <typename T>
+    class multispan_base_t {};
+}
+
+namespace klib {
+    /**
+     * @brief Returns if the template is a multispan a span with a specific type
+     * 
+     * @tparam T 
+     * @tparam G 
+     */
+    template <typename T, typename G>
+    concept is_span_type = (
+        std::is_same_v<std::span<T>, G> || 
+        std::is_base_of<detail::multispan_base_t<T>, G>::value
+    );
+
+    /**
+     * @brief Returns if the template is a multispan a span with a specific type 
+     * (checks both for the normal type and the const type)
+     * 
+     * @tparam T 
+     * @tparam G 
+     */
+    template <typename T, typename G>
+    concept is_span_type_c = (
+        std::is_same_v<std::span<T>, G> || std::is_same_v<std::span<const T>, G> ||
+        std::is_base_of<detail::multispan_base_t<T>, G>::value || 
+        std::is_base_of<detail::multispan_base_t<const T>, G>::value
+    );
+
+    /**
+     * @brief Non owning wrapper to map two std::span in a single array
+     * 
+     * @tparam T 
+     */
+    template <
+        typename T, 
+        typename G = std::span<T>, 
+        typename H = std::span<T>
+    > requires is_span_type<T, G> && is_span_type<T, H>
+    class multispan: public detail::multispan_base_t<T> {
+    protected:
+        // the two internal spans
+        G first;
+        H second;
+
+    public:
+        // member types (no iterators as it is not a continuous 
+        // block of memory)
+        using element_type        = T;
+        using value_type          = std::remove_cv_t<T>;
+        using size_type           = size_t;
+        using difference_type     = ptrdiff_t;
+        using pointer             = T*;
+        using const_pointer       = const T*;
+        using reference           = element_type&;
+        using const_reference     = const element_type&;
+
+        /**
+         * @brief Construct a new multiptr object using a initializer list, raw 
+         * array(not a pointer) or std::array
+         * 
+         * for raw pointers {ptr, size} should be used as a parameter
+         * 
+         * @param first 
+         * @param second 
+         */
+        multispan(const G& first, const H& second):
+            first(first), second(second)
+        {}
+
+        /**
+         * @brief Operator to get data from the two spans
+         * 
+         * @param index 
+         * @return constexpr T& 
+         */
+        constexpr reference operator[](const uint32_t index) const {
+            // check what pointer we should use
+            if (index > first.size()) {
+                return second[index - first.size()];
+            }
+
+            // return the first pointer
+            return first[index];
+        }
+
+        /**
+         * @brief Returns the total size of both spans
+         * 
+         * @return uint32_t 
+         */
+        uint32_t size() const {
+            return first.size() + second.size();
+        }
+
+        uint32_t empty() const {
+            return size() == 0;
+        }
+    };
+}
+
+#endif

--- a/klib/multispan.hpp
+++ b/klib/multispan.hpp
@@ -108,6 +108,11 @@ namespace klib {
             return first.size() + second.size();
         }
 
+        /**
+         * @brief Returns if the span is empty
+         * 
+         * @return uint32_t 
+         */
         uint32_t empty() const {
             return size() == 0;
         }

--- a/klib/multispan.hpp
+++ b/klib/multispan.hpp
@@ -24,7 +24,7 @@ namespace klib {
      */
     template <typename T, typename G>
     concept is_span_type = (
-        std::is_same_v<std::span<T>, G> || 
+        std::is_same_v<std::span<std::remove_reference_t<T>>, G> || 
         std::is_base_of<detail::multispan_base<T>, G>::value
     );
 
@@ -37,7 +37,8 @@ namespace klib {
      */
     template <typename T, typename G>
     concept is_span_type_c = (
-        std::is_same_v<std::span<T>, G> || std::is_same_v<std::span<const T>, G> ||
+        std::is_same_v<std::span<std::remove_reference_t<T>>, G> || 
+        std::is_same_v<std::span<const std::remove_reference_t<T>>, G> ||
         std::is_base_of<detail::multispan_base<T>, G>::value || 
         std::is_base_of<detail::multispan_base<const T>, G>::value
     );

--- a/klib/multispan.hpp
+++ b/klib/multispan.hpp
@@ -12,7 +12,7 @@ namespace klib::detail {
      * @tparam T 
      */
     template <typename T>
-    class multispan_base_t {};
+    class multispan_base {};
 }
 
 namespace klib {
@@ -25,7 +25,7 @@ namespace klib {
     template <typename T, typename G>
     concept is_span_type = (
         std::is_same_v<std::span<T>, G> || 
-        std::is_base_of<detail::multispan_base_t<T>, G>::value
+        std::is_base_of<detail::multispan_base<T>, G>::value
     );
 
     /**
@@ -38,8 +38,8 @@ namespace klib {
     template <typename T, typename G>
     concept is_span_type_c = (
         std::is_same_v<std::span<T>, G> || std::is_same_v<std::span<const T>, G> ||
-        std::is_base_of<detail::multispan_base_t<T>, G>::value || 
-        std::is_base_of<detail::multispan_base_t<const T>, G>::value
+        std::is_base_of<detail::multispan_base<T>, G>::value || 
+        std::is_base_of<detail::multispan_base<const T>, G>::value
     );
 
     /**
@@ -52,7 +52,7 @@ namespace klib {
         typename G = std::span<T>, 
         typename H = std::span<T>
     > requires is_span_type<T, G> && is_span_type<T, H>
-    class multispan: public detail::multispan_base_t<T> {
+    class multispan: public detail::multispan_base<T> {
     protected:
         // the two internal spans
         G first;

--- a/klib/usb/device/bulk.hpp
+++ b/klib/usb/device/bulk.hpp
@@ -197,7 +197,7 @@ namespace klib::usb::device {
 
             // start a read on the endpoint
             Usb::read(callback<Usb>, usb::get_endpoint(config.endpoint1.bEndpointAddress), 
-                usb::endpoint_mode::out, data, size
+                usb::endpoint_mode::out, {data, size}
             );
 
             // check if we should exit
@@ -246,7 +246,7 @@ namespace klib::usb::device {
 
             // start to the write to the endpoint
             if (!Usb::write(callback<Usb>, usb::get_endpoint(config.endpoint0.bEndpointAddress), 
-                usb::get_endpoint_mode(config.endpoint0.bEndpointAddress), data, size))
+                usb::get_endpoint_mode(config.endpoint0.bEndpointAddress), {data, size}))
             {
                 return false;
             }
@@ -446,8 +446,8 @@ namespace klib::usb::device {
             // send the configuration back to the host
             const auto result = Usb::write(
                 usb::status_callback<Usb>, usb::control_endpoint, 
-                usb::endpoint_mode::in, &configuration, 
-                sizeof(configuration)
+                usb::endpoint_mode::in, 
+                {&configuration, sizeof(configuration)}
             );
 
             // check if something went wrong already

--- a/klib/usb/device/dfu.hpp
+++ b/klib/usb/device/dfu.hpp
@@ -248,10 +248,9 @@ namespace klib::usb::device {
                     // this. Data should also be static to make sure it
                     // is still allocated when the dma is sending it)
                     if (Usb::write(callback_handler<Usb>, klib::usb::usb::control_endpoint, 
-                        usb::endpoint_mode::in, const_cast<const uint8_t *>(
+                        usb::endpoint_mode::in, {const_cast<const uint8_t *>(
                             reinterpret_cast<const volatile uint8_t *>(&current_state)
-                        ), 
-                        sizeof(current_state)))
+                        ), sizeof(current_state)}))
                     {
                         // return we should wait on the ack from the write
                         return usb::handshake::wait;
@@ -308,7 +307,8 @@ namespace klib::usb::device {
 
                     // write the status to the host
                     if (Usb::write(callback_handler<Usb>, klib::usb::usb::control_endpoint, 
-                         usb::endpoint_mode::in, reinterpret_cast<const uint8_t *const>(&status), sizeof(status)))
+                         usb::endpoint_mode::in, {reinterpret_cast<const uint8_t *const>(&status), 
+                         sizeof(status)}))
                     {
                         // return we should wait on the ack from the write
                         return usb::handshake::wait;
@@ -375,7 +375,7 @@ namespace klib::usb::device {
 
                     // we have a non 0 length packet. Read the data
                     Usb::read(callback_handler<Usb>, klib::usb::usb::control_endpoint, 
-                        usb::endpoint_mode::in, buffer, length
+                        usb::endpoint_mode::in, {buffer, length}
                     );
 
                     // check if this is a new download
@@ -516,8 +516,8 @@ namespace klib::usb::device {
             // send the configuration back to the host
             const auto result = Usb::write(
                 usb::status_callback<Usb>, usb::control_endpoint, 
-                usb::endpoint_mode::in, &configuration, 
-                sizeof(configuration)
+                usb::endpoint_mode::in, 
+                {&configuration, sizeof(configuration)}
             );
 
             // check if something went wrong already

--- a/klib/usb/device/keyboard.hpp
+++ b/klib/usb/device/keyboard.hpp
@@ -372,7 +372,7 @@ namespace klib::usb::device {
 
             // write the first report to the endpoint
             if (!Usb::write(hid_callback<Usb>, usb::get_endpoint(config.endpoint.bEndpointAddress),
-                usb::endpoint_mode::in, report_data, sizeof(report_data))) 
+                usb::endpoint_mode::in, report_data)) 
             {
                 return false;
             }

--- a/klib/usb/device/keyboard.hpp
+++ b/klib/usb/device/keyboard.hpp
@@ -207,7 +207,7 @@ namespace klib::usb::device {
                 // send the no key pressed to the host
                 Usb::write(
                     hid_callback<Usb>, usb::get_endpoint(config.endpoint.bEndpointAddress),
-                    mode, report_data, sizeof(report_data)
+                    mode, report_data
                 );
 
                 // clear the data to notify we are done with the string
@@ -233,7 +233,7 @@ namespace klib::usb::device {
                 // send the report to the host
                 Usb::write(
                     hid_callback<Usb>, usb::get_endpoint(config.endpoint.bEndpointAddress),
-                    mode, report_data, sizeof(report_data)
+                    mode, report_data
                 );
 
                 // mark we have send a no keys between two repeated keys              
@@ -257,7 +257,7 @@ namespace klib::usb::device {
             // send the report to the host
             Usb::write(
                 hid_callback<Usb>, usb::get_endpoint(config.endpoint.bEndpointAddress),
-                mode, report_data, sizeof(report_data)
+                mode, report_data
             );
 
             // return we are done
@@ -574,8 +574,8 @@ namespace klib::usb::device {
             // send the configuration back to the host
             const auto result = Usb::write(
                 usb::status_callback<Usb>, usb::control_endpoint, 
-                usb::endpoint_mode::in, &configuration, 
-                sizeof(configuration)
+                usb::endpoint_mode::in, 
+                {&configuration, sizeof(configuration)}
             );
 
             // check if something went wrong already
@@ -616,7 +616,7 @@ namespace klib::usb::device {
 
                 // write the inital report
                 if (Usb::write(hid_callback<Usb>, usb::get_endpoint(config.endpoint.bEndpointAddress),
-                    usb::endpoint_mode::in, report_data, sizeof(report_data))) 
+                    usb::endpoint_mode::in, report_data)) 
                 {
                     // no issue for now ack
                     return usb::handshake::ack;
@@ -688,10 +688,8 @@ namespace klib::usb::device {
                     std::fill_n(report_data, sizeof(report_data), 0x00);
 
                     // write the data to the control endpoint
-                    if (Usb::write(
-                            nullptr, usb::control_endpoint, 
-                            usb::endpoint_mode::in, report_data, 
-                            sizeof(report_data))) 
+                    if (Usb::write(nullptr, usb::control_endpoint, 
+                        usb::endpoint_mode::in, report_data)) 
                     {
                         // no issue for now ack
                         return usb::handshake::ack;
@@ -713,10 +711,8 @@ namespace klib::usb::device {
                         const uint8_t idle = 0;
 
                         // write the data to the control endpoint
-                        if (Usb::write(
-                            nullptr, usb::control_endpoint, 
-                            usb::endpoint_mode::in, report_data, 
-                            sizeof(report_data))) 
+                        if (Usb::write(nullptr, usb::control_endpoint, usb::endpoint_mode::in, 
+                            report_data)) 
                         {
                             // no issue for now ack
                             return usb::handshake::ack;

--- a/klib/usb/device/mass_storage.hpp
+++ b/klib/usb/device/mass_storage.hpp
@@ -368,8 +368,8 @@ namespace klib::usb::device {
             // send the configuration back to the host
             const auto result = Usb::write(
                 usb::status_callback<Usb>, usb::control_endpoint, 
-                usb::endpoint_mode::in, &configuration, 
-                sizeof(configuration)
+                usb::endpoint_mode::in, 
+                {&configuration, sizeof(configuration)}
             );
 
             // check if something went wrong already

--- a/klib/usb/device/mouse.hpp
+++ b/klib/usb/device/mouse.hpp
@@ -411,8 +411,8 @@ namespace klib::usb::device {
             // send the configuration back to the host
             const auto result = Usb::write(
                 usb::status_callback<Usb>, usb::control_endpoint, 
-                usb::endpoint_mode::in, &configuration, 
-                sizeof(configuration)
+                usb::endpoint_mode::in, 
+                {&configuration, sizeof(configuration)}
             );
 
             // check if something went wrong already
@@ -453,8 +453,8 @@ namespace klib::usb::device {
 
                 // write the inital report
                 if (Usb::write(hid_callback<Usb>, config.endpoint.bEndpointAddress & 0x0f, 
-                    usb::endpoint_mode::in, reinterpret_cast<const uint8_t*>(&report_data), 
-                    sizeof(report_data))) 
+                    usb::endpoint_mode::in, {reinterpret_cast<const uint8_t*>(&report_data), 
+                    sizeof(report_data)})) 
                 {
                     // no issue for now ack
                     return usb::handshake::ack;
@@ -524,8 +524,8 @@ namespace klib::usb::device {
                     // write the data to the control endpoint
                     if (Usb::write(
                             nullptr, usb::control_endpoint, usb::endpoint_mode::in, 
-                            reinterpret_cast<const uint8_t*>(&report_data), 
-                            sizeof(report_data))) 
+                            {reinterpret_cast<const uint8_t*>(&report_data), 
+                            sizeof(report_data)})) 
                     {
                         // no issue for now ack
                         return usb::handshake::ack;
@@ -549,8 +549,8 @@ namespace klib::usb::device {
                         // write the data to the control endpoint
                         if (Usb::write(
                             nullptr, usb::control_endpoint, usb::endpoint_mode::in, 
-                            reinterpret_cast<const uint8_t*>(&report_data),
-                            sizeof(report_data))) 
+                            {reinterpret_cast<const uint8_t*>(&report_data),
+                            sizeof(report_data)})) 
                         {
                             // no issue for now ack
                             return usb::handshake::ack;

--- a/klib/usb/msc/bulk_only_transfer.hpp
+++ b/klib/usb/msc/bulk_only_transfer.hpp
@@ -65,7 +65,7 @@ namespace klib::usb::msc::bot {
         static usb::handshake get_interface(const klib::usb::setup_packet &packet) {
             if (!Usb::write(usb::status_callback<Usb>,
                 usb::control_endpoint, usb::endpoint_mode::in, 
-                &interface, sizeof(interface)))
+                {&interface, sizeof(interface)}))
             {
                 // something went wrong stall now
                 return usb::handshake::stall;
@@ -95,7 +95,7 @@ namespace klib::usb::msc::bot {
                     // send the maximum amount of supported luns
                     if (!Usb::write(callback_handler<Usb, state::wait_for_cbw>,
                         usb::control_endpoint, usb::endpoint_mode::in,
-                        &max_lun, sizeof(max_lun)))
+                        {&max_lun, sizeof(max_lun)}))
                     {
                         // something went wrong stall now
                         return usb::handshake::stall;
@@ -185,8 +185,7 @@ namespace klib::usb::msc::bot {
             Usb::read(callback_handler<Usb, state::receive_cbw>, 
                 usb::get_endpoint(OutEndpoint), 
                 usb::get_endpoint_mode(OutEndpoint), 
-                reinterpret_cast<uint8_t*>(&cbw), 
-                sizeof(cbw)
+                {reinterpret_cast<uint8_t*>(&cbw), sizeof(cbw)}
             );
         }
 
@@ -319,8 +318,7 @@ namespace klib::usb::msc::bot {
             Usb::write(callback_handler<Usb, state::wait_for_cbw>, 
                 usb::get_endpoint(InEndpoint),
                 usb::get_endpoint_mode(InEndpoint),
-                reinterpret_cast<uint8_t*>(&csw),
-                sizeof(csw)
+                {reinterpret_cast<uint8_t*>(&csw), sizeof(csw)}
             );
         }
 
@@ -369,7 +367,7 @@ namespace klib::usb::msc::bot {
             Usb::write(callback_handler<Usb, state::send_csw>, 
                 usb::get_endpoint(InEndpoint),
                 usb::get_endpoint_mode(InEndpoint),
-                block_buffer, sizeof(response)
+                block_buffer
             );
         }
 
@@ -396,7 +394,7 @@ namespace klib::usb::msc::bot {
             Usb::write(callback_handler<Usb, state::send_csw>, 
                 usb::get_endpoint(InEndpoint),
                 usb::get_endpoint_mode(InEndpoint),
-                buffer, sizeof(buffer)
+                buffer
             );
         }
 
@@ -414,7 +412,7 @@ namespace klib::usb::msc::bot {
             Usb::write(callback_handler<Usb, state::send_csw>, 
                 usb::get_endpoint(InEndpoint),
                 usb::get_endpoint_mode(InEndpoint),
-                buffer, sizeof(buffer)
+                buffer
             );   
         }
 
@@ -427,7 +425,7 @@ namespace klib::usb::msc::bot {
             Usb::write(callback_handler<Usb, state::send_csw>, 
                 usb::get_endpoint(InEndpoint),
                 usb::get_endpoint_mode(InEndpoint),
-                buffer, sizeof(buffer)
+                buffer
             );   
         }
         
@@ -459,7 +457,7 @@ namespace klib::usb::msc::bot {
             Usb::write(callback_handler<Usb, state::send_csw>, 
                 usb::get_endpoint(InEndpoint),
                 usb::get_endpoint_mode(InEndpoint),
-                buffer, sizeof(buffer)
+                buffer
             );            
         }
 
@@ -481,7 +479,7 @@ namespace klib::usb::msc::bot {
             Usb::write(callback_handler<Usb, state::send_csw>, 
                 usb::get_endpoint(InEndpoint),
                 usb::get_endpoint_mode(InEndpoint),
-                block_buffer, sizeof(response)
+                block_buffer
             );            
         }
 
@@ -508,7 +506,7 @@ namespace klib::usb::msc::bot {
             Usb::write(callback_handler<Usb, state::send_csw>, 
                 usb::get_endpoint(InEndpoint),
                 usb::get_endpoint_mode(InEndpoint),
-                buffer, sizeof(buffer)
+                buffer
             );            
         }
 
@@ -531,7 +529,7 @@ namespace klib::usb::msc::bot {
                 Usb::write(callback_handler<Usb, state::memory_read>, 
                     usb::get_endpoint(InEndpoint),
                     usb::get_endpoint_mode(InEndpoint),
-                    block_buffer, sizeof(block_buffer)
+                    block_buffer
                 );                    
             }
             else {
@@ -548,7 +546,7 @@ namespace klib::usb::msc::bot {
                     callback_handler<Usb, state::memory_write>, 
                     usb::get_endpoint(OutEndpoint),
                     usb::get_endpoint_mode(OutEndpoint),
-                    block_buffer, sizeof(block_buffer)
+                    block_buffer
                 );
             }
             else {

--- a/klib/usb/msc/bulk_only_transfer.hpp
+++ b/klib/usb/msc/bulk_only_transfer.hpp
@@ -367,7 +367,7 @@ namespace klib::usb::msc::bot {
             Usb::write(callback_handler<Usb, state::send_csw>, 
                 usb::get_endpoint(InEndpoint),
                 usb::get_endpoint_mode(InEndpoint),
-                block_buffer
+                {reinterpret_cast<const uint8_t*>(&response), sizeof(response)}
             );
         }
 
@@ -479,7 +479,7 @@ namespace klib::usb::msc::bot {
             Usb::write(callback_handler<Usb, state::send_csw>, 
                 usb::get_endpoint(InEndpoint),
                 usb::get_endpoint_mode(InEndpoint),
-                block_buffer
+                {reinterpret_cast<const uint8_t*>(&response), sizeof(response)}
             );            
         }
 

--- a/klib/usb/usb.hpp
+++ b/klib/usb/usb.hpp
@@ -385,7 +385,9 @@ namespace klib::usb {
             const uint32_t size = klib::min(descriptor.size, static_cast<uint32_t>(packet.wLength));
 
             // write the data to the endpoint buffer and check if we directly fail
-            if (Usb::write(status_callback<Usb>, control_endpoint, endpoint_mode::in, {descriptor.desc, size})) {
+            if (Usb::write(status_callback<Usb>, control_endpoint, endpoint_mode::in, 
+                {descriptor.desc, size})) 
+            {
                 // no errors return we need to wait on the callback
                 return handshake::wait;
             }

--- a/klib/usb/usb.hpp
+++ b/klib/usb/usb.hpp
@@ -179,7 +179,7 @@ namespace klib::usb {
             }
 
             // write and check if we got any errors straight away
-            if (Usb::write(status_callback<Usb>, control_endpoint, endpoint_mode::in, response, sizeof(response))) {
+            if (Usb::write(status_callback<Usb>, control_endpoint, endpoint_mode::in, response)) {
                 // no errors return we need to wait on the callback
                 return handshake::wait;
             }
@@ -385,7 +385,7 @@ namespace klib::usb {
             const uint32_t size = klib::min(descriptor.size, static_cast<uint32_t>(packet.wLength));
 
             // write the data to the endpoint buffer and check if we directly fail
-            if (Usb::write(status_callback<Usb>, control_endpoint, endpoint_mode::in, descriptor.desc, size)) {
+            if (Usb::write(status_callback<Usb>, control_endpoint, endpoint_mode::in, {descriptor.desc, size})) {
                 // no errors return we need to wait on the callback
                 return handshake::wait;
             }

--- a/targets/core/nxp/lpc175x/dma.hpp
+++ b/targets/core/nxp/lpc175x/dma.hpp
@@ -2,6 +2,7 @@
 #define KLIB_NXP_LPC175X_DMA_HPP
 
 #include <array>
+#include <span>
 
 #include <klib/klib.hpp>
 #include <klib/io/dma.hpp>
@@ -297,15 +298,18 @@ namespace klib::core::lpc175x::io {
          * @param size 
          */
         template <bool MemoryIncrement = true, typename T>
-        static void write(const T *const source, uint16_t size) {
+        static void write(const std::span<T>& source) {
             static_assert(std::is_same_v<Source, klib::io::dma::memory>, "Source needs to be memory for this function");
             static_assert(!std::is_same_v<Destination, klib::io::dma::memory>, "Destination needs to be a peripheral for this function");
+
+            // get the amount of bytes we need to transmit
+            const uint32_t size = source.size_bytes();
 
             // set the dma destination
             Dma::port->CH[Channel].DESTADDR = reinterpret_cast<uint32_t>(Destination::template dma_data<0>());
 
             // update the helper data with the information about the transfer
-            helper.data = reinterpret_cast<const uint8_t*>(source);
+            helper.data = reinterpret_cast<const uint8_t*>(source.data());
             helper.requested_size = size;
             helper.transferred_size = 0x00;
 
@@ -347,15 +351,18 @@ namespace klib::core::lpc175x::io {
          * @param size 
          */
         template <bool MemoryIncrement = true, typename T>
-        static void read(T *const destination, uint16_t size) {
+        static void read(const std::span<T>& destination) {
             static_assert(!std::is_same_v<Source, klib::io::dma::memory>, "Source needs to be a peripheral for this function");
             static_assert(std::is_same_v<Destination, klib::io::dma::memory>, "Destination needs to be memory for this function");
+
+            // get the amount of bytes we need to transmit
+            const uint32_t size = destination.size_bytes();
 
             // set the source and destination
             Dma::port->CH[Channel].SRCADDR = reinterpret_cast<uint32_t>(Source::template dma_data<1>());
 
             // update the helper data with the information about the transfer
-            helper.data = reinterpret_cast<const uint8_t*>(destination);
+            helper.data = reinterpret_cast<const uint8_t*>(destination.data());
             helper.requested_size = size;
             helper.transferred_size = 0x00;
 

--- a/targets/core/nxp/lpc175x/rtc.hpp
+++ b/targets/core/nxp/lpc175x/rtc.hpp
@@ -19,7 +19,7 @@ namespace klib::core::lpc175x::io {
          * @param cal_value 
          * @param cal_direction
          */
-        static void init(const uint16_t cal_value = 0, const bool cal_direction = 1) {
+        static void init(const uint32_t cal_value = 0, const bool cal_direction = 1) {
             // enable the power for the rtc
             target::io::power_control::enable<Rtc>();
 
@@ -42,7 +42,7 @@ namespace klib::core::lpc175x::io {
             Rtc::port->AMR = 0xff;
 
             // setup the calibration if we have any
-            Rtc::port->CALIBRATION = cal_value | (cal_direction << 17);
+            Rtc::port->CALIBRATION = (cal_value & 0x1ffff) | (cal_direction << 17);
 
             // enable the rtc
             Rtc::port->CCR = 0x1 | ((cal_value == 0) ? (0x1 << 4) : 0x00);

--- a/targets/core/nxp/lpc175x/spi.hpp
+++ b/targets/core/nxp/lpc175x/spi.hpp
@@ -166,8 +166,7 @@ namespace klib::core::lpc175x::io {
          * @param tx 
          * @param rx 
          */
-        template <typename T, typename G>
-        static void write_read(const std::span<const uint8_t>& tx, const multispan<uint8_t, T, G>& rx) {
+        static void write_read(const std::span<const uint8_t>& tx, const multispan<uint8_t>& rx) {
             return write_read_helper(tx, rx);
         }
 
@@ -177,13 +176,7 @@ namespace klib::core::lpc175x::io {
          * @param tx 
          * @param rx 
          */
-        template <
-            typename T, typename E, typename F
-        >
-        requires (
-            std::same_as<std::remove_cv_t<T>, uint8_t>
-        )
-        static void write_read(const multispan<T, E, F>& tx, const std::span<uint8_t>& rx) {
+        static void write_read(const multispan<const uint8_t>& tx, const std::span<uint8_t>& rx) {
             return write_read_helper(tx, rx);
         }
 
@@ -193,14 +186,7 @@ namespace klib::core::lpc175x::io {
          * @param tx 
          * @param rx 
          */
-        template <
-            typename T, typename E, typename F, 
-            typename G, typename H
-        >
-        requires (
-            std::same_as<std::remove_cv_t<T>, uint8_t>
-        ) 
-        static void write_read(const multispan<T, E, F>& tx, const multispan<uint8_t, G, H>& rx) {
+        static void write_read(const multispan<const uint8_t>& tx, const multispan<uint8_t>& rx) {
             return write_read_helper(tx, rx);
         }
 
@@ -218,13 +204,7 @@ namespace klib::core::lpc175x::io {
          * 
          * @param data 
          */
-        template <
-            typename T, typename E, typename F
-        >
-        requires (
-            std::same_as<std::remove_cv_t<T>, uint8_t>
-        )
-        static void write(const multispan<T, E, F>& data) {
+        static void write(const multispan<const uint8_t>& data) {
             return write_helper(data);
         }
     };

--- a/targets/core/nxp/lpc17xx/ssp.hpp
+++ b/targets/core/nxp/lpc17xx/ssp.hpp
@@ -192,11 +192,8 @@ namespace klib::core::lpc17xx::io {
          * @param tx 
          * @param rx 
          */
-        template <
-            bool Async = false, typename T, 
-            typename G
-        >
-        static void write_read(const std::span<const uint8_t>& tx, const multispan<uint8_t, T, G>& rx) {
+        template <bool Async = false>
+        static void write_read(const std::span<const uint8_t>& tx, const multispan<uint8_t>& rx) {
             return write_read_helper<Async>(tx, rx);
         }
 
@@ -206,14 +203,8 @@ namespace klib::core::lpc17xx::io {
          * @param tx 
          * @param rx 
          */
-        template <
-            bool Async = false, typename T, 
-            typename E, typename F
-        >
-        requires (
-            std::same_as<std::remove_cv_t<T>, uint8_t>
-        )
-        static void write_read(const multispan<T, E, F>& tx, const std::span<uint8_t>& rx) {
+        template <bool Async = false>
+        static void write_read(const multispan<const uint8_t>& tx, const std::span<uint8_t>& rx) {
             return write_read_helper<Async>(tx, rx);
         }
 
@@ -223,14 +214,8 @@ namespace klib::core::lpc17xx::io {
          * @param tx 
          * @param rx 
          */
-        template <
-            bool Async = false, typename T, typename E, 
-            typename F, typename G, typename H
-        >
-        requires (
-            std::same_as<std::remove_cv_t<T>, uint8_t>
-        ) 
-        static void write_read(const multispan<T, E, F>& tx, const multispan<uint8_t, G, H>& rx) {
+        template <bool Async = false>
+        static void write_read(const multispan<const uint8_t>& tx, const multispan<uint8_t>& rx) {
             return write_read_helper<Async>(tx, rx);
         }
 
@@ -249,14 +234,8 @@ namespace klib::core::lpc17xx::io {
          * 
          * @param data 
          */
-        template <
-            bool Async = false, typename T, 
-            typename E, typename F
-        >
-        requires (
-            std::same_as<std::remove_cv_t<T>, uint8_t>
-        )
-        static void write(const multispan<T, E, F>& data) {
+        template <bool Async = false>
+        static void write(const multispan<const uint8_t>& data) {
             return write_read_helper<Async>(data);
         }
 

--- a/targets/core/nxp/lpc17xx/ssp.hpp
+++ b/targets/core/nxp/lpc17xx/ssp.hpp
@@ -226,7 +226,7 @@ namespace klib::core::lpc17xx::io {
          */
         template <bool Async = false>
         static void write(const std::span<const uint8_t>& data) {
-            return write_read_helper<Async>(data);
+            return write_read_helper<Async>(data, std::span<uint8_t>{});
         }
 
         /**
@@ -236,7 +236,7 @@ namespace klib::core::lpc17xx::io {
          */
         template <bool Async = false>
         static void write(const multispan<const uint8_t>& data) {
-            return write_read_helper<Async>(data);
+            return write_read_helper<Async>(data, std::span<uint8_t>{});
         }
 
         /**

--- a/targets/core/nxp/lpc17xx/ssp.hpp
+++ b/targets/core/nxp/lpc17xx/ssp.hpp
@@ -36,8 +36,10 @@ namespace klib::core::lpc17xx::io {
         static uint16_t write_fifo(const T& data, const uint16_t size, const uint16_t transmitted) {
             uint16_t t = 0;
 
-            // write as many bytes until the fifo is full
-            while ((Ssp::port->SR & (0x1 << 1)) && ((transmitted + t) < size)) {
+            // write as many bytes until the fifo is full (or until we have half 
+            // the rx fifo filled. This is so we do not miss any received data 
+            // when high ssp speeds are used)
+            while ((Ssp::port->SR & (0x1 << 1)) && ((transmitted + t) < size) && !(Ssp::port->RIS & (0x1 << 2))) {
                 // write dummy data if we dont have data or if we need 
                 // to send more data we have in the buffer
                 if (data.empty() || ((transmitted + t) >= data.size())) {

--- a/targets/core/nxp/lpc17xx/ssp.hpp
+++ b/targets/core/nxp/lpc17xx/ssp.hpp
@@ -140,7 +140,6 @@ namespace klib::core::lpc17xx::io {
          * 
          * @param tx 
          * @param rx 
-         * @param size 
          */
         template <
             bool Async = false,
@@ -180,7 +179,6 @@ namespace klib::core::lpc17xx::io {
          * @warning not all data is written unless not busy anymore
          * 
          * @param data 
-         * @param size 
          */
         template <bool Async = false, typename T = std::span<const uint8_t>>
         static void write(const T& data) requires is_span_type_c<uint8_t, T> {

--- a/targets/core/nxp/lpc17xx/ssp.hpp
+++ b/targets/core/nxp/lpc17xx/ssp.hpp
@@ -182,7 +182,7 @@ namespace klib::core::lpc17xx::io {
          */
         template <bool Async = false, typename T = std::span<const uint8_t>>
         static void write(const T& data) requires is_span_type_c<uint8_t, T> {
-            write_read<Async>(data, {nullptr, 0});
+            write_read<Async>(data, std::span<uint8_t>());
         }
 
         /**

--- a/targets/core/nxp/lpc17xx/usb.hpp
+++ b/targets/core/nxp/lpc17xx/usb.hpp
@@ -960,8 +960,7 @@ namespace klib::core::lpc17xx::io {
          * @param callback 
          * @param endpoint 
          * @param mode
-         * @param data 
-         * @param size 
+         * @param data
          * @return true 
          * @return false 
          */

--- a/targets/lpc802/io/spi.hpp
+++ b/targets/lpc802/io/spi.hpp
@@ -230,8 +230,7 @@ namespace klib::lpc802::io {
          * @param tx 
          * @param rx 
          */
-        template <typename T, typename G>
-        static void write_read(const std::span<const uint8_t>& tx, const multispan<uint8_t, T, G>& rx) {
+        static void write_read(const std::span<const uint8_t>& tx, const multispan<uint8_t>& rx) {
             return write_read_helper(tx, rx);
         }
 
@@ -241,13 +240,7 @@ namespace klib::lpc802::io {
          * @param tx 
          * @param rx 
          */
-        template <
-            typename T, typename E, typename F
-        >
-        requires (
-            std::same_as<std::remove_cv_t<T>, uint8_t>
-        )
-        static void write_read(const multispan<T, E, F>& tx, const std::span<uint8_t>& rx) {
+        static void write_read(const multispan<const uint8_t>& tx, const std::span<uint8_t>& rx) {
             return write_read_helper(tx, rx);
         }
 
@@ -257,14 +250,7 @@ namespace klib::lpc802::io {
          * @param tx 
          * @param rx 
          */
-        template <
-            typename T, typename E, typename F, 
-            typename G, typename H
-        >
-        requires (
-            std::same_as<std::remove_cv_t<T>, uint8_t>
-        ) 
-        static void write_read(const multispan<T, E, F>& tx, const multispan<uint8_t, G, H>& rx) {
+        static void write_read(const multispan<const uint8_t>& tx, const multispan<uint8_t>& rx) {
             return write_read_helper(tx, rx);
         }
 
@@ -282,13 +268,7 @@ namespace klib::lpc802::io {
          * 
          * @param data 
          */
-        template <
-            typename T, typename E, typename F
-        >
-        requires (
-            std::same_as<std::remove_cv_t<T>, uint8_t>
-        )
-        static void write(const multispan<T, E, F>& data) {
+        static void write(const multispan<const uint8_t>& data) {
             return write_helper(data);
         }
     };

--- a/targets/max32660/io/flash.hpp
+++ b/targets/max32660/io/flash.hpp
@@ -224,8 +224,7 @@ namespace klib::max32660::io {
          * @return true 
          * @return false 
          */
-        template <typename T, typename G>
-        static bool write(const uint32_t address, const klib::multispan<const uint8_t, T, G>& data) {
+        static bool write(const uint32_t address, const klib::multispan<const uint8_t>& data) {
             return write_helper(address, data);
         }
     };

--- a/targets/max32660/io/flash.hpp
+++ b/targets/max32660/io/flash.hpp
@@ -225,7 +225,7 @@ namespace klib::max32660::io {
          * @return false 
          */
         template <typename T, typename G>
-        static bool write(const uint32_t address, const klib::multispan<uint8_t, T, G>& data) {
+        static bool write(const uint32_t address, const klib::multispan<const uint8_t, T, G>& data) {
             return write_helper(address, data);
         }
     };

--- a/targets/max32660/io/flash.hpp
+++ b/targets/max32660/io/flash.hpp
@@ -2,7 +2,9 @@
 #define KLIB_MAX32660_FLASH_HPP
 
 #include <cstdint>
+
 #include <klib/io/core_clock.hpp>
+#include <klib/multispan.hpp>
 
 #include <max32660.hpp>
 
@@ -21,6 +23,10 @@ namespace klib::max32660::io {
     template <typename Flc>
     class flash {
     protected:
+        /**
+         * @brief Init the FLC clock to 1 mhz
+         * 
+         */
         static void init_clock() {
             // get the core clock
             const auto clock = klib::io::clock::get();
@@ -29,63 +35,33 @@ namespace klib::max32660::io {
             Flc::port->FLSH_CLKDIV = clock / 1'000'000;
         }
 
+        /**
+         * @brief Unlock the flash
+         * 
+         */
         static void unlock_flash() {
             // unlock the flash by setting the unlock value to 0x2
             Flc::port->FLSH_CN &= ~(0x7 << 28);
             Flc::port->FLSH_CN |= (0x2 << 28);
         }
 
+        /**
+         * @brief Lock the flash
+         * 
+         */
         static void lock_flash() {
             // lock the flash again by clearing the unlock value and the erase code
             Flc::port->FLSH_CN &= ~((0x7 << 28) & (0xff << 8));
         }
 
-    public:
-    	static bool erase_page(const uint32_t address) {
-            // wait until the flash is ready
-            while (Flc::port->FLSH_CN & (0x1 << 24)) {
-                // do nothing
-            }
-
-            // clear all interrupt flags
-            Flc::port->FLSH_INTR = 0;
-
-            // init the flc clock
-            init_clock();
-
-            // set the address
-            Flc::port->FLSH_ADDR = address; 
-
-            // set the page erase code
-            Flc::port->FLSH_CN &= ~(0xff << 8);
-            Flc::port->FLSH_CN |= (0x55 << 8);
-
-            // unlock the flash
-            unlock_flash();
-
-            // wait until the flash is ready
-            while (Flc::port->FLSH_CN & (0x1 << 24)) {
-                // do nothing
-            }
-            
-            // start a page erase
-            Flc::port->FLSH_CN |= 0x1 << 2;
-
-            // wait until the page erase is done
-            while (Flc::port->FLSH_CN & (0x1 << 2)) {
-                // do nothing
-            }
-
-            // lock the flash again
-            lock_flash();
-
-            // get the status
-            const uint32_t status = Flc::port->FLSH_INTR;
-
-            // return if the operation has completed
-            return (status & 0x1) && !(status & (0x1 << 1));
-        }
-
+        /**
+         * @brief Writes 4 bytes of data to address
+         * 
+         * @param address 
+         * @param value 
+         * @return true 
+         * @return false 
+         */
         static bool write(const uint32_t address, const uint32_t value) {
             // wait until the flash is ready
             while (Flc::port->FLSH_CN & (0x1 << 24)) {
@@ -133,6 +109,125 @@ namespace klib::max32660::io {
             return (status & 0x1) && !(status & (0x1 << 1));
         }
 
+        /**
+         * @brief Write helper that writes data in 4 byte chunks
+         * 
+         * @tparam T 
+         * @param address 
+         * @param data 
+         * @return true 
+         * @return false 
+         */
+        template <typename T>
+        static bool write_helper(const uint32_t address, const T& data) {
+            // write all the data we have
+            for (uint32_t i = 0; i < data.size_bytes(); i += 4) {
+                // write in 4 byte chunks
+                const auto x = write(address + i, 
+                    (data[i] << 24) | (data[i + 1] << 16) | 
+                    (data[i + 2] << 8) | data[i + 1]
+                );
+
+                // check the result
+                if (!x) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+    public:
+        /**
+         * @brief Available erase modes
+         * 
+         * sector size = 8192 bytes
+         */
+        enum class erase_mode {
+            sector,
+        };
+
+        /**
+         * @brief Erase using the mode
+         * 
+         * @param mode 
+         * @param address 
+         * @return true 
+         * @return false 
+         */
+    	static bool erase(const erase_mode mode, const uint32_t address) {
+            // wait until the flash is ready
+            while (Flc::port->FLSH_CN & (0x1 << 24)) {
+                // do nothing
+            }
+
+            // clear all interrupt flags
+            Flc::port->FLSH_INTR = 0;
+
+            // init the flc clock
+            init_clock();
+
+            // set the address
+            Flc::port->FLSH_ADDR = address; 
+
+            // set the page erase code
+            Flc::port->FLSH_CN &= ~(0xff << 8);
+            Flc::port->FLSH_CN |= (0x55 << 8);
+
+            // unlock the flash
+            unlock_flash();
+
+            // wait until the flash is ready
+            while (Flc::port->FLSH_CN & (0x1 << 24)) {
+                // do nothing
+            }
+            
+            // start a page erase
+            Flc::port->FLSH_CN |= 0x1 << 2;
+
+            // wait until the page erase is done
+            while (Flc::port->FLSH_CN & (0x1 << 2)) {
+                // do nothing
+            }
+
+            // lock the flash again
+            lock_flash();
+
+            // get the status
+            const uint32_t status = Flc::port->FLSH_INTR;
+
+            // return if the operation has completed
+            return (status & 0x1) && !(status & (0x1 << 1));
+        }
+
+        /**
+         * @brief Write to the address with data
+         * 
+         * @warning can only write multiplies of 4 bytes at a time
+         * 
+         * @tparam T 
+         * @param address 
+         * @param data 
+         * @return success
+         */
+        static bool write(const uint32_t address, const std::span<const uint8_t>& data) {
+            return write_helper(address, data);
+        }
+
+        /**
+         * @brief Write to the address with data
+         * 
+         * @tparam T 
+         * @tparam G 
+         * @param address 
+         * @param data 
+         * @return true 
+         * @return false 
+         */
+        template <typename T, typename G>
+        static bool write(const uint32_t address, const klib::multispan<uint8_t, T, G>& data) {
+            return write_helper(address, data);
+        }
     };
 }
 

--- a/targets/max32660/io/spi.hpp
+++ b/targets/max32660/io/spi.hpp
@@ -380,20 +380,15 @@ namespace klib::max32660::io {
             // enable the transmit fifo port
             setup_fifo<true, false>();
 
-            // get the amount of data to receive and transmit. The smaller 
-            // between the two must still write/read the data to clear the
-            // fifo
-            const uint32_t size = klib::max(tx.size(), rx.size());
-
             // set the amount of character we want to receive/write
-            Spi::port->CTRL1 = size;
+            Spi::port->CTRL1 = data.size();
 
             uint32_t transmitted = 0;
             bool started = false;
 
-            while ((size - transmitted) > 0) {
+            while ((data.size() - transmitted) > 0) {
                 // write the tx data
-                transmitted += write_fifo(data, size, transmitted);
+                transmitted += write_fifo(data, data.size(), transmitted);
 
                 // check if the transmission is already started
                 if (!started && transmitted) {

--- a/targets/max32660/io/spi.hpp
+++ b/targets/max32660/io/spi.hpp
@@ -380,6 +380,11 @@ namespace klib::max32660::io {
             // enable the transmit fifo port
             setup_fifo<true, false>();
 
+            // get the amount of data to receive and transmit. The smaller 
+            // between the two must still write/read the data to clear the
+            // fifo
+            const uint32_t size = klib::max(tx.size(), rx.size());
+
             // set the amount of character we want to receive/write
             Spi::port->CTRL1 = size;
 


### PR DESCRIPTION
changes old style raw pointers + size to a span/multispan.

Note some peripherals (dma and usb) do not support multispans. They reference the memory directly and do not use operator[] for reading new data. These peripherals did change to accept std::span as parameters